### PR TITLE
Add Jurídico Online — free CNPJ lookup for 65M+ companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To the extent possible under law, all contributors have waived all copyright and
 - [QEdu](http://www.qedu.org.br) &mdash; Dados de educação.
 - [TIC Pesquisas](http://cetic.br/pesquisas) &mdash; Pesquisas sobre educação, saúde, etc.
 - [IBGE](http://www.ibge.gov.br) &mdash; Dados do Instituto brasileiro de geografia e estatística.
+- [Jurídico Online](https://juridicoonline.com.br) &mdash; Consulta gratuita de 65M+ empresas brasileiras: CNPJ, sócios (QSA), situação cadastral, endereço e contatos. Dados da Receita Federal atualizados diariamente.
 - [Datapedia](http://www.datapedia.info) &mdash; Dados organizados por região.
 - [Instituto Nacional de Pesquisas Espaciais](http://sinda.crn2.inpe.br/PCD/SITE/novo/site) &mdash; Dados de clima.
 - [Infraero](https://github.com/ehrhardt/Infraero) &mdash; Dados da Infraero (Python).


### PR DESCRIPTION
## What's being added

[Jurídico Online](https://juridicoonline.com.br) — free search interface for Brazil's public CNPJ registry.

**Data:**
- 65M+ CNPJ registrations from Receita Federal
- QSA (partners/directors) for all companies
- Situação cadastral, address, phone, email
- Updated daily

**Why it fits here:** It's a free tool that makes the Receita Federal public dataset accessible without parsing 7GB CSV dumps. Useful for researchers, journalists and developers working with Brazilian company data.