### PR TITLE
Adiciona logos-bancos-br (dataset de instituições financeiras do Brasil)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To the extent possible under law, all contributors have waived all copyright and
 - [Crime Brasil](https://crimebrasil.com.br) &mdash; Dados de ocorrências criminais geocodificadas por bairro (RS), município (MG/RJ) e nacionais (PRF/DATASUS). API REST + CSV/Parquet, CC BY 4.0.
 - [ANP-TERRESTRE](https://reate.cprm.gov.br/anp/TERRESTRE) &mdash; Dados públicos de sísmica terrestre disponibilizados de forma gratuita pela ANP.
 - [DeBRief.jl](https://github.com/dantebertuzzi/DeBRief.jl) &mdash; Estatísticas de crime e violência publicadas pelo ministério da justiça e segurança pública (Julia).
+- [logos-bancos-br](https://github.com/rzmt/logos-bancos-br) &mdash; Dataset e logos oficiais de instituições financeiras do Brasil (bancos, fintechs, IPs, cooperativas), derivados só de fontes oficiais (listas de participantes do STR e do Pix do Banco Central e diretório do Open Finance Brasil), com proveniência por logo e atualização semanal.
 
 ## Acre
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To the extent possible under law, all contributors have waived all copyright and
 - [Crime Brasil](https://crimebrasil.com.br) &mdash; Dados de ocorrências criminais geocodificadas por bairro (RS), município (MG/RJ) e nacionais (PRF/DATASUS). API REST + CSV/Parquet, CC BY 4.0.
 - [ANP-TERRESTRE](https://reate.cprm.gov.br/anp/TERRESTRE) &mdash; Dados públicos de sísmica terrestre disponibilizados de forma gratuita pela ANP.
 - [DeBRief.jl](https://github.com/dantebertuzzi/DeBRief.jl) &mdash; Estatísticas de crime e violência publicadas pelo ministério da justiça e segurança pública (Julia).
-- [logos-bancos-br](https://github.com/rzmt/logos-bancos-br) &mdash; Dataset e logos oficiais de instituições financeiras do Brasil (bancos, fintechs, IPs, cooperativas), derivados só de fontes oficiais (listas de participantes do STR e do Pix do Banco Central e diretório do Open Finance Brasil), com proveniência por logo e atualização semanal.
+- [logos-bancos-br](https://github.com/rzmt/logos-bancos-br) &mdash; Logos de instituições financeiras do Brasil (JavaScript).
 
 ## Acre
 


### PR DESCRIPTION
Adiciona o **logos-bancos-br** à seção `## Brasil`.

É um dataset + logos oficiais das instituições financeiras do Brasil (bancos, fintechs, IPs, cooperativas), derivado **só de fontes oficiais**: as listas de participantes do STR e do Pix do Banco Central e o diretório de participantes do Open Finance Brasil. Cada logo carrega proveniência (URI de origem, SHA-256 e data), e a lista é reconstruída automaticamente toda semana por CI.

- 1.113 instituições (ISPB, COMPE, CNPJ, atributos de participação no Pix); 475 com logo oficial
- Distribuído como JSON puro, via CDN (jsDelivr) sem instalar nada, ou como pacote npm
- MIT, código aberto: https://github.com/rzmt/logos-bancos-br

Segue o formato do guia de contribuição (`[Título](link) &mdash; Descrição.`), sem trailing whitespace.