### PR TITLE
Adiciona Databook e Logibook à seção Brasil

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ To the extent possible under law, all contributors have waived all copyright and
 - [GeoSGB](https://geosgb.sgb.gov.br) &mdash; Dados públicos do serviço geológico do Brasil (site alternativo).
 - [DeBRief.jl](https://github.com/dantebertuzzi/DeBRief.jl) &mdash; Estatísticas de crime e violência publicadas pelo ministério da justiça e segurança pública (Julia).
 - [logos-bancos-br](https://github.com/rzmt/logos-bancos-br) &mdash; Logos de instituições financeiras do Brasil (JavaScript).
+- [Databook](https://databook.dataint.net/pt/paises/brasil/) &mdash; Dados públicos consolidados por país em 15 secções (população, economia, saúde, educação, infraestrutura, ambiente), com 67 fontes citadas — Banco Mundial, OMS, UNESCO, ONU DESA, CIA World Factbook. Cada indicador traz fonte e ano.
+- [Logibook](https://logibook.dataint.net/pt/paises/brasil) &mdash; Dados de logística e comércio: 39 portos, 193 aeroportos, 391 códigos UN/LOCODE e 24 zonas de comércio, a partir de NGA World Port Index, OurAirports, UNCTAD e Banco Mundial.
 
 ## Acre
 


### PR DESCRIPTION
Adiciona duas entradas à seção **Brasil**.

Sendo direto desde já: os dois sites são meus. Deixo a decisão com você — se
não se encaixarem no escopo da lista, feche o PR sem cerimônia.

**O que são.** Desde que a CIA parou de atualizar o World Factbook em fevereiro
de 2026, venho montando dois sites que consolidam dados públicos por país.
Ambos são gratuitos, sem cadastro e sem assinatura; vivem de publicidade.

- **Databook** — 15 secções para o Brasil, 67 fontes citadas (Banco Mundial,
  OMS, UNESCO, ONU DESA, CIA World Factbook). Cada indicador aparece com a
  fonte e o ano.
- **Logibook** — o lado logístico: 39 portos, 193 aeroportos, 391 códigos
  UN/LOCODE, 24 zonas de comércio.

**O que não são.** Não produzo dado primário e não ofereço API nem download em
massa. O que faço é reunir fontes públicas existentes e apresentá-las de forma
legível, sempre com a proveniência à vista. Pelo critério da lista — *"curated
list of Brazilian datasets"* — isso pode ou não qualificar, e quem decide é
você. Notei que a seção já mistura fontes navegáveis (QEdu, Datapedia) com
outras baixáveis, então imaginei que valeria propor.

Os números acima foram conferidos nas próprias páginas hoje, não são estimativas.

Obrigado pela lista.
