### PR TITLE
Add stackin-io/data-source to Brasil section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ To the extent possible under law, all contributors have waived all copyright and
 - [GeoSGB](https://geosgb.sgb.gov.br) &mdash; Dados públicos do serviço geológico do Brasil (site alternativo).
 - [DeBRief.jl](https://github.com/dantebertuzzi/DeBRief.jl) &mdash; Estatísticas de crime e violência publicadas pelo ministério da justiça e segurança pública (Julia).
 - [logos-bancos-br](https://github.com/rzmt/logos-bancos-br) &mdash; Logos de instituições financeiras do Brasil (JavaScript).
+- [stackin-io/data-source](https://github.com/stackin-io/data-source) &mdash; Publicações oficiais dos documentos fiscais eletrônicos brasileiros (NF-e, NFC-e, CT-e, MDF-e, BP-e, NFS-e, NF3e, NFCom e outros) espelhadas do portal SEFAZ, ADN gov.br e SVRS. Feed Atom e manifest JSON atualizados diariamente.
 
 ## Acre
 


### PR DESCRIPTION
Adiciona [stackin-io/data-source](https://github.com/stackin-io/data-source) à seção Brasil.

Discussão prévia: #13.

Espelho versionado + feed Atom + manifest JSON das publicações oficiais dos documentos fiscais eletrônicos brasileiros (NF-e, NFC-e, CT-e, MDF-e, BP-e, NFS-e, NF3e, NFCom, NFAG, NFGAS, DC-e, NFABI, DIFAL, NFF, PES, ONE), com fontes do portal SEFAZ nacional, do ADN gov.br e do portal DF-e SVRS (atende 22 UFs). Atualização automática diária.