### PR TITLE
Add cTribNac: códigos de tributação nacional da NFS-e (JSON/CSV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ To the extent possible under law, all contributors have waived all copyright and
 - [DeBRief.jl](https://github.com/dantebertuzzi/DeBRief.jl) &mdash; Estatísticas de crime e violência publicadas pelo ministério da justiça e segurança pública (Julia).
 - [logos-bancos-br](https://github.com/rzmt/logos-bancos-br) &mdash; Logos de instituições financeiras do Brasil (JavaScript).
 - [stackin-io/data-source](https://github.com/stackin-io/data-source) &mdash; Publicações oficiais dos documentos fiscais eletrônicos brasileiros.
+- [cTribNac (NFS-e Nacional)](https://github.com/transformax2205-droid/codigo-tributacao-nacional-nfse) &mdash; Tabela oficial dos 338 códigos de tributação nacional da NFS-e Nacional (LC 116/2003) em JSON e CSV, com busca.
 
 ## Acre
 


### PR DESCRIPTION
Adiciona na seção Brasil a tabela oficial dos 338 códigos de tributação nacional (cTribNac) da NFS-e Nacional, derivada da lista de serviços da LC 116/2003 (fonte: anexo do Emissor Nacional, gov.br/nfse). Dados em JSON e CSV, licença CC BY 4.0, com busca por código ou descrição.

Linha no mesmo formato das demais entradas (`[Título](link) &mdash; Descrição.`), sem espaço em branco no fim. Não encontrei entrada equivalente na lista.

Obrigado pela curadoria!